### PR TITLE
Minor change to LineType input

### DIFF
--- a/moorpy/MoorProps.py
+++ b/moorpy/MoorProps.py
@@ -194,7 +194,7 @@ def getLineProps(dmm, type="chain", stud="studless", source="Orcaflex-altered", 
     notes = f"made with getLineProps - source: {source}"
     
 
-    return mp.LineType(typestring, d_vol, massden, EA, MBL=MBL, cost=cost, notes=notes, input_type=type, input_d=dmm)
+    return mp.LineType(typestring, d_vol, massden, EA, MBL=MBL, cost=cost, notes=notes, input_type=type, d_nom=dmm)
 
 
 #----NOTES----


### PR DESCRIPTION
## Purpose

WISDEM uses this `MoorProps` object.  Should we still use it?  If so, a minor change is needed in the constructor of `LineType` to keep using it.

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior.

## Checklist
_Put an `x` in the boxes that apply._

- [ ] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation