### PR TITLE
Fix NameError in Subsystem.getYawStiffness (undefined 'l')

### DIFF
--- a/moorpy/subsystem.py
+++ b/moorpy/subsystem.py
@@ -902,7 +902,7 @@ class Subsystem(System, Line):
         
         tau0 = -self.fB[0]  # horizontal tension component [N]
 
-        yaw_stiff = (tau0/l)*self.rad_fair**2 + tau0*self.rad_fair  # [N-m]
+        yaw_stiff = (tau0/self.span)*self.rad_fair**2 + tau0*self.rad_fair  # [N-m]
         
         return yaw_stiff
 

--- a/tests/test_subsystem.py
+++ b/tests/test_subsystem.py
@@ -12,6 +12,24 @@ from moorpy.helpers import getLineProps
 import matplotlib.pyplot as plt
 
 
+def test_getYawStiffness_runs():
+    """Subsystem.getYawStiffness must not raise NameError.
+
+    Regression test: the yaw-stiffness formula referenced an undefined local
+    ``l`` (a leftover from the rename of line length to ``span``), so every
+    call raised ``NameError: name 'l' is not defined``. It should instead use
+    ``self.span`` and return ``(tau0/span)*rad_fair**2 + tau0*rad_fair``.
+    """
+    ss = mp.Subsystem(depth=100, span=200, rad_fair=10, z_fair=-10)
+    # getYawStiffness reads the horizontal fairlead force fB (set during a
+    # solve); inject a representative value to exercise the formula directly.
+    ss.fB = np.array([-1.0e5, 0.0, 5.0e4])
+
+    tau0 = -ss.fB[0]
+    expected = (tau0 / ss.span) * ss.rad_fair**2 + tau0 * ss.rad_fair
+    assert_allclose(ss.getYawStiffness(), expected)
+
+
 """
 def test_tensions_swap():
     '''Compares two equivalent catenary mooring lines that are defined in opposite directions.'''


### PR DESCRIPTION
Calling `Subsystem.getYawStiffness()` always raises `NameError: name 'l' is not defined`.

## The bug

```python
def getYawStiffness(self):
    tau0 = -self.fB[0]  # horizontal tension component [N]
    yaw_stiff = (tau0/l)*self.rad_fair**2 + tau0*self.rad_fair  # [N-m]   # <- l undefined
    return yaw_stiff
```

`l` is never assigned in the method (no local, no attribute, no global), so every call fails. `git blame` points to commit `2f330c8` *"Subsystem updates for `span` consistency"* — the rename of the line length to `span` missed this one site, leaving the stale `l`.

## The fix

Use `self.span` (the horizontal end-to-end distance, set in `__init__`), which is the length the formula intends:

```python
yaw_stiff = (tau0/self.span)*self.rad_fair**2 + tau0*self.rad_fair  # [N-m]
```

Dimensionally consistent: `[N]/[m]·[m²] + [N]·[m] = [N·m]`.

## Reproduction (before this PR)

```python
import numpy as np
import moorpy as mp

ss = mp.Subsystem(depth=100, span=200, rad_fair=10, z_fair=-10)
ss.fB = np.array([-1.0e5, 0.0, 5.0e4])   # horizontal fairlead force
ss.getYawStiffness()        # -> NameError: name 'l' is not defined
```

## Verification

- New regression test `tests/test_subsystem.py::test_getYawStiffness_runs` asserts the call returns the documented value `(tau0/span)*rad_fair**2 + tau0*rad_fair`. It **fails on `dev`** (`NameError`) and **passes** with this fix.
- Full test suite: `29 passed`.